### PR TITLE
only update id when zero val and non-negotiated

### DIFF
--- a/src/data_channel/mod.rs
+++ b/src/data_channel/mod.rs
@@ -157,7 +157,7 @@ impl RTCDataChannel {
                 negotiated: self.negotiated,
             };
 
-            if self.id.load(Ordering::SeqCst) == 0 {
+            if self.id.load(Ordering::SeqCst) == 0 && !self.negotiated {
                 self.id.store(
                     sctp_transport
                         .generate_and_set_data_channel_id(


### PR DESCRIPTION
Per https://w3c.github.io/webrtc-pc/#dom-rtcdatachannel-id, we should only update data channel id if it's null (by existing crate convention, `0`) AND not negotiated.